### PR TITLE
Redirect to base path of serverless-offline

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -36,9 +36,11 @@ const runServices = (services: Service[], httpPort: number, stage: string, prefi
 const runProxy = (services: Service[], httpPort: number, stage: string) => {
     const app = express();
 
-    for (let i = 0; i < services.length; i++) {
 
-        app.use(`/${services[i].srvPath}/`, createProxyMiddleware({
+    for (let i = 0; i < services.length; i++) {
+	const proxyPath = `/${services[i].srvPath}/`
+        app.use(proxyPath ,createProxyMiddleware({
+	    pathRewrite: (path, req) => { return path.replace(proxyPath, '/') },
             target: `http://localhost:${httpPort + i}/${stage}/`,
             changeOrigin: true,
         }));

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -38,10 +38,11 @@ const runProxy = (services: Service[], httpPort: number, stage: string) => {
 
 
     for (let i = 0; i < services.length; i++) {
-	const proxyPath = `/${services[i].srvPath}`
+        const proxyPath = `/${services[i].srvPath}`
+        const stripBasePath = services[i].stripBasePath
         app.use(proxyPath ,createProxyMiddleware({
 	        pathRewrite: (path: string) => { 
-                if (services[i].stripBasePath) {
+                if (stripBasePath) {
                     return path.replace(proxyPath, '/') 
                 } else {
                     return path

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -38,9 +38,15 @@ const runProxy = (services: Service[], httpPort: number, stage: string) => {
 
 
     for (let i = 0; i < services.length; i++) {
-	const proxyPath = `/${services[i].srvPath}/`
+	const proxyPath = `/${services[i].srvPath}`
         app.use(proxyPath ,createProxyMiddleware({
-	    pathRewrite: (path, req) => { return path.replace(proxyPath, '/') },
+	        pathRewrite: (path: string) => { 
+                if (services[i].stripBasePath) {
+                    return path.replace(proxyPath, '/') 
+                } else {
+                    return path
+                }
+            },
             target: `http://localhost:${httpPort + i}/${stage}/`,
             changeOrigin: true,
         }));

--- a/src/types/service.ts
+++ b/src/types/service.ts
@@ -2,4 +2,5 @@ export interface Service {
     srvName: string;
     srvSource: string;
     srvPath: string;
+    stripBasePath: boolean;
 }


### PR DESCRIPTION
@edis thanks for the useful project. This change makes sure the srvPath set in the config is removed when passed to the serverless-offline localhost. In the current state, requests are passed with addition path parts and hit the wrong URI.

Thanks!